### PR TITLE
Pin version to same version as in localstack

### DIFF
--- a/stepfunctions-local-patch/Makefile
+++ b/stepfunctions-local-patch/Makefile
@@ -4,7 +4,7 @@ usage:		## Show this help
 
 extract:	## Extract stepfunctions libs from docker image
 	rm -rf ./lib ; \
-	docker_id=$$(docker run -d --entrypoint="" amazon/aws-stepfunctions-local:latest /bin/sleep infinity) ; \
+	docker_id=$$(docker run -d --entrypoint="" amazon/aws-stepfunctions-local:1.7.9 /bin/sleep infinity) ; \
 	docker cp $$docker_id:/home/stepfunctionslocal/ ./lib ; \
 	docker kill $$docker_id ; \
 	wget -O lib/aspectjrt-1.9.7.jar https://repo1.maven.org/maven2/org/aspectj/aspectjrt/1.9.7/aspectjrt-1.9.7.jar; \


### PR DESCRIPTION
We're currently still using the `1.7.9` version of the stepfunctions-local image since the newer ones have quite dramatically increased in size.

This PR pins the version to be the same as in localstack to avoid any issues when extracting files. It should have no direct effect on the behavior of localstack right now and is only a preventative step.