### PR TITLE
Set s3ForcePathStyle for S3 client in SFn internal SDK

### DIFF
--- a/stepfunctions-internal-awssdk/src/index.js
+++ b/stepfunctions-internal-awssdk/src/index.js
@@ -41,7 +41,8 @@ var handler = async ({ service, operation, params, region }) => {
         credentials: {
           accessKeyId: "test",
           secretAccessKey: "test"
-        }
+        },
+        s3ForcePathStyle: true
       });
       const fn = Reflect.get(client, operation);
       const response = Reflect.apply(fn, client, [params]);

--- a/stepfunctions-internal-awssdk/src/index.js
+++ b/stepfunctions-internal-awssdk/src/index.js
@@ -35,15 +35,18 @@ var handler = async ({ service, operation, params, region }) => {
   if (serviceKey) {
     try {
       const service2 = Reflect.get(AWS, serviceKey);
-      const client = new service2({
+      const config = {
         endpoint,
         region,
         credentials: {
           accessKeyId: "test",
           secretAccessKey: "test"
-        },
-        s3ForcePathStyle: true
-      });
+        }
+      }
+      if (serviceKey.toLowerCase() === "s3") {
+        config.s3ForcePathStyle = true;
+      }
+      const client = new service2(config);
       const fn = Reflect.get(client, operation);
       const response = Reflect.apply(fn, client, [params]);
       const result = await response.promise();


### PR DESCRIPTION
Set `s3ForcePathStyle` for S3 client in SFn internal SDK - fixes an error when running an AWS SDK call from a StepFunction execution:

```
  originalError: Error: getaddrinfo ENOTFOUND test-bucket-be014846.192.168.65.2
      at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:71:26) {
    errno: -3008,
    code: 'NetworkingError',
```