### PR TITLE
Add certificate automation

### DIFF
--- a/.github/workflows/renew-certificate.yml
+++ b/.github/workflows/renew-certificate.yml
@@ -37,8 +37,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
       - name: Set up Python
         id: setup-python
         uses: actions/setup-python@v4
@@ -58,7 +56,7 @@ jobs:
           ./generate-certificate.sh
       - name: Commit certificate
         working-directory: "local-certs"
-        # if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         run: |
           git config user.name ${{ env.git_user_name }}
           git config user.email ${{ env.git_user_email }}

--- a/.github/workflows/renew-certificate.yml
+++ b/.github/workflows/renew-certificate.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
       - name: Set up Python
         id: setup-python
         uses: actions/setup-python@v4

--- a/.github/workflows/renew-certificate.yml
+++ b/.github/workflows/renew-certificate.yml
@@ -1,0 +1,61 @@
+name: Renew Certificate
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/renew-certificate.yml"
+      - "local-certs/certificate-domains"
+      - "local-certs/certificate-regions"
+      - "local-certs/generate-domains.py"
+      - "local-certs/generate-certificate.sh"
+    branches:
+      - master
+  push:
+    paths:
+      - ".github/workflows/renew-certificate.yml"
+      - "local-certs/certificate-domains"
+      - "local-certs/certificate-regions"
+      - "local-certs/generate-domains.py"
+      - "local-certs/generate-certificate.sh"
+    branches:
+      - master
+
+env:
+  git_user_name: localstack[bot]
+  git_user_email: localstack-bot@users.noreply.github.com
+
+jobs:
+  renew-certificate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        id: setup-python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install Certbot
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          pip install certbot certbot-plugin-gandi
+      - name: Generate certificate
+        working-directory: "local-certs"
+        env:
+          CERTBOT_ARGS: "${{ github.ref == 'refs/heads/master' && '' || '--staging' }}"
+          DNS_API_KEY: "${{ secrets.DNS_API_KEY }}"
+          CERTBOT_EMAIL: ${{ env.git_user_email }}
+        run: |
+          ./generate-certificate.sh
+      - name: Commit certificate
+        working-directory: "local-certs"
+        if: github.ref == 'refs/heads/master'
+        run: |
+          git config user.name ${{ env.git_user_name }}
+          git config user.email ${{ env.git_user_email }}
+          git add server.key
+          expiry_date=$(date --date="$(openssl x509 -enddate -noout -in server.key | cut -d= -f 2)" --utc --iso-8601)
+          git commit -m "update local certificate keys (new expiry date: $expiry_date)"
+          git push
+     

--- a/.github/workflows/renew-certificate.yml
+++ b/.github/workflows/renew-certificate.yml
@@ -27,6 +27,9 @@ env:
   git_user_name: localstack[bot]
   git_user_email: localstack-bot@users.noreply.github.com
 
+permissions:
+  contents: write
+
 jobs:
   renew-certificate:
     runs-on: ubuntu-latest
@@ -53,7 +56,7 @@ jobs:
           ./generate-certificate.sh
       - name: Commit certificate
         working-directory: "local-certs"
-        if: github.ref == 'refs/heads/master'
+        # if: github.ref == 'refs/heads/master'
         run: |
           git config user.name ${{ env.git_user_name }}
           git config user.email ${{ env.git_user_email }}

--- a/.github/workflows/renew-certificate.yml
+++ b/.github/workflows/renew-certificate.yml
@@ -19,6 +19,9 @@ on:
       - "local-certs/generate-certificate.sh"
     branches:
       - master
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 6 1 * *'
 
 env:
   git_user_name: localstack[bot]

--- a/local-certs/.gitignore
+++ b/local-certs/.gitignore
@@ -1,0 +1,4 @@
+gandi.ini
+config/
+logs/
+work/

--- a/local-certs/README.md
+++ b/local-certs/README.md
@@ -1,0 +1,20 @@
+## Certificate renewal
+The current certificate for `localhost.localstack.cloud` and several of its subdomains are stored in `server.key`.
+
+The file contains both certificate and private key.
+
+### Limitations
+Please make sure to conform to the [LetsEncrypt Rate Limits](https://letsencrypt.org/docs/rate-limits/).
+
+Most notably, do not rerequest the certficate for the same set of domain names more than 5 times a week, for new domain names more than 50 times a week and no more than 100 names in total per certificate.
+
+
+### Domain lists
+
+* `certificate-domains` contains a list (newline separated) with all domains the certificate should be valid for. It allows `{region}` as placeholder, to generate domains for multiple regions.
+* `certificate-regions` contains a list (newline separated) of all regions which will be substituted for the `{region}` placeholder.
+
+
+### Timeline
+
+The certificate renewal will happen every time the domain/region list are updated, or every month.

--- a/local-certs/certificate-domains
+++ b/local-certs/certificate-domains
@@ -1,0 +1,11 @@
+localhost.localstack.cloud
+*.localhost.localstack.cloud
+*.amplifyapp.localhost.localstack.cloud
+*.cloudfront.localhost.localstack.cloud
+*.elb.localhost.localstack.cloud
+*.execute-api.localhost.localstack.cloud
+*.opensearch.localhost.localstack.cloud
+*.s3-website.localhost.localstack.cloud
+*.s3.localhost.localstack.cloud
+*.scm.localhost.localstack.cloud
+*.dkr.ecr.{region}.localhost.localstack.cloud

--- a/local-certs/certificate-domains
+++ b/local-certs/certificate-domains
@@ -9,3 +9,4 @@ localhost.localstack.cloud
 *.s3.localhost.localstack.cloud
 *.scm.localhost.localstack.cloud
 *.dkr.ecr.{region}.localhost.localstack.cloud
+*.lambda-url.{region}.localhost.localstack.cloud

--- a/local-certs/certificate-regions
+++ b/local-certs/certificate-regions
@@ -1,0 +1,2 @@
+us-east-1
+eu-central-1

--- a/local-certs/certificate-regions
+++ b/local-certs/certificate-regions
@@ -1,2 +1,6 @@
-us-east-1
 eu-central-1
+eu-west-1
+us-east-1
+us-east-2
+us-west-1
+us-west-2

--- a/local-certs/generate-certificate.sh
+++ b/local-certs/generate-certificate.sh
@@ -9,8 +9,11 @@ echo "Generating certificate for domains ${certificate_domains}"
 echo "dns_gandi_api_key=${DNS_API_KEY}" > gandi.ini
 chmod 600 gandi.ini
 
+# request certificate
+set -x
 # TODO replace with `certbot` after trial run
 echo -n --agree-tos --email ${CERTBOT_EMAIL} ${CERTBOT_ARGS} --authenticator dns-gandi --dns-gandi-credentials gandi.ini --work-dir=$PWD/work --config-dir=$PWD/config --logs-dir=$PWD/logs -d $certificate_domains certonly
+set +x
 
 # remove credentials to avoid accidental leakage
 rm gandi.ini

--- a/local-certs/generate-certificate.sh
+++ b/local-certs/generate-certificate.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+# generate comma separated list of all domains to request a cert for
+certificate_domains=$(python generate-domains.py)
+echo "Generating certificate for domains ${certificate_domains}"
+
+# create credentials file
+echo "dns_gandi_api_key=${DNS_API_KEY}" > gandi.ini
+chmod 600 gandi.ini
+
+# TODO replace with `certbot` after trial run
+echo -n --agree-tos --email ${CERTBOT_EMAIL} ${CERTBOT_ARGS} --authenticator dns-gandi --dns-gandi-credentials gandi.ini --work-dir=$PWD/work --config-dir=$PWD/config --logs-dir=$PWD/logs -d $certificate_domains certonly
+
+# remove credentials to avoid accidental leakage
+rm gandi.ini
+
+# concatinate private key + cert into single file to match current structure
+echo "Concatinating certificate and key into single file"
+cat config/live/localhost.localstack.cloud/privkey.pem config/live/localhost.localstack.cloud/fullchain.pem > server.key
+
+# display certificate information
+echo "Certificate information"
+openssl x509 -in server.key -text -noout

--- a/local-certs/generate-certificate.sh
+++ b/local-certs/generate-certificate.sh
@@ -12,7 +12,7 @@ chmod 600 gandi.ini
 # request certificate
 set -x
 # TODO replace with `certbot` after trial run
-echo -n --agree-tos --email ${CERTBOT_EMAIL} ${CERTBOT_ARGS} --authenticator dns-gandi --dns-gandi-credentials gandi.ini --work-dir=$PWD/work --config-dir=$PWD/config --logs-dir=$PWD/logs -d $certificate_domains certonly
+certbot -n --agree-tos --email ${CERTBOT_EMAIL} ${CERTBOT_ARGS} --authenticator dns-gandi --dns-gandi-credentials gandi.ini --work-dir=$PWD/work --config-dir=$PWD/config --logs-dir=$PWD/logs -d $certificate_domains certonly
 set +x
 
 # remove credentials to avoid accidental leakage

--- a/local-certs/generate-certificate.sh
+++ b/local-certs/generate-certificate.sh
@@ -11,7 +11,6 @@ chmod 600 gandi.ini
 
 # request certificate
 set -x
-# TODO replace with `certbot` after trial run
 certbot -n --agree-tos --email ${CERTBOT_EMAIL} ${CERTBOT_ARGS} --authenticator dns-gandi --dns-gandi-credentials gandi.ini --work-dir=$PWD/work --config-dir=$PWD/config --logs-dir=$PWD/logs -d $certificate_domains certonly
 set +x
 

--- a/local-certs/generate-domains.py
+++ b/local-certs/generate-domains.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+"""
+This file generates a comma-separated list of domains,
+by replacing the occurences of "{region}" in the domains
+in "certificate-domains" by the regions in "certificate-regions"
+"""
+
+
+REGION_PLACEHOLDER = "{region}"
+
+
+def generate_domains(domain_list: list[str], region_list: list[str]) -> list[str]:
+    result = []
+    for domain in domain_list:
+        if REGION_PLACEHOLDER in domain:
+            result += [domain.replace(REGION_PLACEHOLDER, region) for region in region_list]
+        else:
+            result.append(domain)
+    return result
+
+def main():
+    with open("certificate-domains", mode="rt") as f:
+        domain_list = f.read().splitlines()
+    with open("certificate-regions", mode="rt") as f:
+        region_list = f.read().splitlines()
+    expanded_list = generate_domains(domain_list, region_list)
+    print(",".join(expanded_list), end="")
+    
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Motivation
Currently, we manually renew the certificate, without a proper way to add new certificate names to this procedure.

This raises certain issues, e.g. during vacation times / unavailability, or just the possibility of forgetting it.

We want a method to automatically update certificates, and use version control on the list of its domains.

Also, if we move to more and more regional endpoints, we need a proper way to specify a name pattern which should be added for all supported regions.

## Changes
* Add workflow to the artifacts repo to automatically renew the cert every month, or on workflow dispatch, or changes to the files used for generation.
* If not on master, we check against Let's Encrypt staging environment, not against the production one
* If on master, we push a new commit with the new certificate if it is updated.
* Add a generation of domain names by combining the `certificate-domains` and `certificate-regions` files.

## Caveats
We have to manually track and take care of the let's encrypt rate limits (https://letsencrypt.org/docs/rate-limits/)