### PR TITLE
Pin certificate server key type to RSA

### DIFF
--- a/local-certs/generate-certificate.sh
+++ b/local-certs/generate-certificate.sh
@@ -11,7 +11,7 @@ chmod 600 gandi.ini
 
 # request certificate
 set -x
-certbot -n --agree-tos --email ${CERTBOT_EMAIL} ${CERTBOT_ARGS} --authenticator dns-gandi --dns-gandi-credentials gandi.ini --work-dir=$PWD/work --config-dir=$PWD/config --logs-dir=$PWD/logs -d $certificate_domains certonly
+certbot -n --agree-tos --email ${CERTBOT_EMAIL} ${CERTBOT_ARGS} --authenticator dns-gandi --dns-gandi-credentials gandi.ini --key-type rsa --work-dir=$PWD/work --config-dir=$PWD/config --logs-dir=$PWD/logs -d $certificate_domains certonly
 set +x
 
 # remove credentials to avoid accidental leakage


### PR DESCRIPTION
## Motivation
Currently, our certificate workflow would use the certbot default - ECDSA, as generated server key.

However, this breaks LocalStack's EKS implementation, since it seems our proxy implementation does not like ECDSA public keys, and will somehow break the client certificates necessary for authentication with the k3s API.

It will lead to the following errors in k3s:
```
localstack_main  | E0821 08:06:18.027860      83 authentication.go:63] "Unable to authenticate the request" err="[x509: certificate signed by unknown authority, verifying certificate SN=428217389087803287667876166580439937980685, SKID=48:C1:E1:76:BE:19:EC:D3:E0:55:58:6C:17:5A:D4:5D:35:FB:B9:70, AKID=14:2E:B3:17:B7:58:56:CB:AE:50:09:40:E6:1F:AF:9D:8B:14:C2:C6 failed: x509: certificate signed by unknown authority]"
localstack_main  | E0821 08:06:20.056375      83 authentication.go:63] "Unable to authenticate the request" err="[x509: certificate signed by unknown authority, verifying certificate SN=428217389087803287667876166580439937980685, SKID=48:C1:E1:76:BE:19:EC:D3:E0:55:58:6C:17:5A:D4:5D:35:FB:B9:70, AKID=14:2E:B3:17:B7:58:56:CB:AE:50:09:40:E6:1F:AF:9D:8B:14:C2:C6 failed: x509: certificate signed by unknown authority]"
localstack_main  | E0821 08:06:22.083400      83 authentication.go:63] "Unable to authenticate the request" err="[x509: certificate signed by unknown authority, verifying certificate SN=428217389087803287667876166580439937980685, SKID=48:C1:E1:76:BE:19:EC:D3:E0:55:58:6C:17:5A:D4:5D:35:FB:B9:70, AKID=14:2E:B3:17:B7:58:56:CB:AE:50:09:40:E6:1F:AF:9D:8B:14:C2:C6 failed: x509: certificate signed by unknown authority]"
localstack_main  | E0821 08:06:24.109302      83 authentication.go:63] "Unable to authenticate the request" err="[x509: certificate signed by unknown authority, verifying certificate SN=428217389087803287667876166580439937980685, SKID=48:C1:E1:76:BE:19:EC:D3:E0:55:58:6C:17:5A:D4:5D:35:FB:B9:70, AKID=14:2E:B3:17:B7:58:56:CB:AE:50:09:40:E6:1F:AF:9D:8B:14:C2:C6 failed: x509: certificate signed by unknown authority]"
localstack_main  | E0821 08:06:26.136980      83 authentication.go:63] "Unable to authenticate the request" err="[x509: certificate signed by unknown authority, verifying certificate SN=428217389087803287667876166580439937980685, SKID=48:C1:E1:76:BE:19:EC:D3:E0:55:58:6C:17:5A:D4:5D:35:FB:B9:70, AKID=14:2E:B3:17:B7:58:56:CB:AE:50:09:40:E6:1F:AF:9D:8B:14:C2:C6 failed: x509: certificate signed by unknown authority]"
localstack_main  | E0821 08:06:28.166789      83 authentication.go:63] "Unable to authenticate the request" err="[x509: certificate signed by unknown authority, verifying certificate SN=428217389087803287667876166580439937980685, SKID=48:C1:E1:76:BE:19:EC:D3:E0:55:58:6C:17:5A:D4:5D:35:FB:B9:70, AKID=14:2E:B3:17:B7:58:56:CB:AE:50:09:40:E6:1F:AF:9D:8B:14:C2:C6 failed: x509: certificate signed by unknown authority]"
```

For now, we need to pin an RSA server key to avoid breaking behavior, until we can replace the proxy library (necessary for python3.11 as well).

## Changes
* Pin server key to RSA