### PR TITLE
Add SQS endpoint to cert domains

### DIFF
--- a/local-certs/certificate-domains
+++ b/local-certs/certificate-domains
@@ -10,3 +10,4 @@ localhost.localstack.cloud
 *.scm.localhost.localstack.cloud
 *.dkr.ecr.{region}.localhost.localstack.cloud
 *.lambda-url.{region}.localhost.localstack.cloud
+sqs.{region}.localhost.localstack.cloud


### PR DESCRIPTION
This PR adds the URL scheme introduced by the new SQS `standard` endpoint strategy, to the cert FQDN.