### PR TITLE
add snowflake endpoint to certificate

### DIFF
--- a/local-certs/certificate-domains
+++ b/local-certs/certificate-domains
@@ -11,3 +11,4 @@ localhost.localstack.cloud
 *.dkr.ecr.{region}.localhost.localstack.cloud
 *.lambda-url.{region}.localhost.localstack.cloud
 sqs.{region}.localhost.localstack.cloud
+*.snowflake.localhost.localstack.cloud


### PR DESCRIPTION
this PR adds the snowflake endpoint to our certificate. This should hopefully resolve the issue we're currently having with a customer trying out our extension