### PR TITLE
add region based opensearch endpoint certificate

### DIFF
--- a/local-certs/certificate-domains
+++ b/local-certs/certificate-domains
@@ -5,6 +5,7 @@ localhost.localstack.cloud
 *.elb.localhost.localstack.cloud
 *.execute-api.localhost.localstack.cloud
 *.opensearch.localhost.localstack.cloud
+*.{region}.opensearch.localhost.localstack.cloud
 *.s3-website.localhost.localstack.cloud
 *.s3.localhost.localstack.cloud
 *.scm.localhost.localstack.cloud


### PR DESCRIPTION
This PR would solve issue [#9824](https://github.com/localstack/localstack/issues/9824) that enables Eddu Melendez (Testcontainres) to test & contribute to the LangChain4j project, which uses AWS OpenSearch API as one of the clients and enforces the use of [https](https://github.com/opensearch-project/opensearch-java/blob/ef04bf87b3557e6f090e41859a8c356a111224e2/java-client/src/main/java/org/opensearch/client/transport/aws/AwsSdk2Transport.java#L287).