### PR TITLE
Upgrade version of Kafka embedded server to 3.2.7

### DIFF
--- a/kafka-server/.gitignore
+++ b/kafka-server/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 kafka-server.iml
 local.properties
+kafka-embedded-env/

--- a/kafka-server/Makefile
+++ b/kafka-server/Makefile
@@ -1,8 +1,23 @@
+KAFKA_EMBEDDED_ENV_VERSION ?= 3.2.7
+KAFKA_EMBEDDED_ENV_COMMIT ?= a5a21c8c6593d30860160cff54ffd350f7e1a0d5
 
 usage:        ## Show this help
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
 
+patch:        ## Clone and patch the kafka-embedded-env repo, build code into local Maven repo
+	test -e kafka-embedded-env || git clone https://github.com/navikt/kafka-embedded-env
+	(cd kafka-embedded-env; git checkout $(KAFKA_EMBEDDED_ENV_COMMIT))
+	# note: using perl instead of sed below, for better Linux/MacOS cross-compatibility
+	perl -i -pe 's|<jvmTarget>17<|<jvmTarget>11<|g' kafka-embedded-env/pom.xml
+	perl -i -pe 's|<maven\.compiler\.source>17<|<maven.compiler.source>11<|g' kafka-embedded-env/pom.xml
+	perl -i -pe 's|<maven\.compiler\.target>17<|<maven.compiler.target>11<|g' kafka-embedded-env/pom.xml
+	(cd kafka-embedded-env; mvn -B versions:set -DnewVersion="$(KAFKA_EMBEDDED_ENV_VERSION)" -DgenerateBackupPoms=false)
+	(cd kafka-embedded-env; mvn install)
+
 build:        ## Build the JAR file
 	gradle shadowJar
 
-.PHONY: build
+clean:        ## Clean up local temporary files
+	rm -rf kafka-embedded-env
+
+.PHONY: usage build patch clean

--- a/kafka-server/README.md
+++ b/kafka-server/README.md
@@ -7,9 +7,24 @@
 
 ## Building
 
+Note: recent versions of [`kafka-embedded-env`](https://github.com/navikt/kafka-embedded-env) require Java 17+, whereas we only have JRE 11 installed in the LocalStack container.
+Hence, we first need to check out and patch the repo locally:
+```
+make patch
+```
+
 To build the latest version of the embedded server, run this command:
 ```
 make build
 ```
 
 On successful build, this will generate a file `build/libs/kafka-server-all.jar` which should then be renamed to `kafka-server-all-<version>.jar` (e.g., `kafka-server-all-3.1.0.jar`) and pushed to the `localstack-assets` S3 bucket.
+
+## Upgrading
+
+To upgrade to a newer version, follow these steps:
+
+* Adjust `KAFKA_EMBEDDED_ENV_VERSION` and `KAFKA_EMBEDDED_ENV_COMMIT` in `Makefile`
+* Adjust the version in `implementation("no.nav:kafka-embedded-env:<version>")` in `build.gradle`
+* Run `make clean` to ensure that local patches are cleaned up
+* Run `make patch` and `make build` as per instructions further above

--- a/kafka-server/build.gradle
+++ b/kafka-server/build.gradle
@@ -6,6 +6,7 @@ plugins {
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
     maven {
       url 'https://packages.confluent.io/maven'
@@ -16,8 +17,7 @@ repositories {
 }
 
 dependencies {
-    // note: later versions of kafka-embedded-env require Java 17+, whereas we only have JRE 11 installed in the LS container
-    implementation("no.nav:kafka-embedded-env:3.1.0") {
+    implementation("no.nav:kafka-embedded-env:3.2.7") {
         exclude group: 'log4j', module: 'log4j'
         // exclude libs to prevent CVEs with certain versions
         exclude group: 'io.confluent', module: 'confluent-log4j'


### PR DESCRIPTION
Upgrade version of Kafka embedded server to 3.2.7. /cc @alexrashed 

Turns out that newer versions of the library are only published for Java 17+ , hence we need to apply a patch here to compile the code under Java 11.

Built and uploaded the new file here: https://localstack-assets.s3.amazonaws.com/kafka-server-all-3.6.1.jar (apprx. 104MB; previous versions were 74.2MB (version 3.1.0) and 51.5MB (version 2.8.0))

**Summary of changes:**
* Create new `patch` make target to clone the https://github.com/navikt/kafka-embedded-env repo, apply patches and compile the code under Java 11
* bump version of `no.nav:kafka-embedded-env` to `3.2.7` in `build.gradle`. Note that this will be taken from the local Maven libs cache (enabled by adding `mavenLocal()`)
* add basic upgrade info to README

**Discussion points:**
* Over time we could consider finding an alternative approach - potentially. The https://github.com/navikt/kafka-embedded-env repo doesn't seem to be very widely used (at least based on GH stars), but on the positive side it still seems to be somewhat actively maintained (last commit ~2 weeks ago)