### PR TITLE
Azure: Add ACR to certificate-domains

### DIFF
--- a/local-certs/certificate-domains
+++ b/local-certs/certificate-domains
@@ -13,3 +13,4 @@ localhost.localstack.cloud
 *.lambda-url.{region}.localhost.localstack.cloud
 sqs.{region}.localhost.localstack.cloud
 *.snowflake.localhost.localstack.cloud
+*.acurecr.localhost.localstack.cloud


### PR DESCRIPTION
New entry for the certificate domains to use this mechanicsm for Azure Container Registry (ACR).

Note that there is no rush behind this - [the current implementation](https://github.com/localstack/localstack-ext/pull/4178) just has some limitations that we need to address at some point, and that needs an HTTPS domain name.

On the naming:
The original URL is `{registry_name}.azurecr.io`, so keeping the `azurecr` in the host is for users an easy way to identify what this URL is about.
I've considered using a generic prefix to separate this domain from the AWS ones, like `acr.azure.localhost.localstack.cloud`, but the term `ACR` is already unique to Azure - so adding `azure` again does not add any new information IMO.
